### PR TITLE
fix(env): correct type

### DIFF
--- a/env.d.ts
+++ b/env.d.ts
@@ -1,7 +1,7 @@
-import type { Sentry } from '@sentry/node'
+import * as Sentry from '@sentry/node'
 
 declare module 'h3' {
   interface H3EventContext {
-    $sentry?: Sentry
+    $sentry?: typeof Sentry
   }
 }


### PR DESCRIPTION
It appears to me that `@sentry/node` does not export any type. Instead I propose this change.