### PR TITLE
chore(api): remove `async` specifier

### DIFF
--- a/server/api/my-endpoints.ts
+++ b/server/api/my-endpoints.ts
@@ -1,4 +1,4 @@
-export default defineEventHandler(async (event) => {
+export default defineEventHandler((event) => {
   if (event.context.$sentry) {
     // Do something here
     event.context.$sentry.captureException(new Error('Test error'))


### PR DESCRIPTION
The function's body does not contain any `await` statement, so I propose to remove the `async` specifier.